### PR TITLE
test pour les notices détaillées

### DIFF
--- a/js/prmBriefResultContainerAfter/linkToExternalSearchSystem.js
+++ b/js/prmBriefResultContainerAfter/linkToExternalSearchSystem.js
@@ -4,6 +4,10 @@
 import linkToExternalSearchSystem from './linkToExternalSearchSystem.html'
 class linkToExternalSearchSystemController {
     constructor($scope, $window, favSession){
+        if (typeof this.parentCtrl.searchStateService.resultObject.info == 'undefined') {
+          // Notice détaillée
+          return;
+        }
         console.log(this.parentCtrl.storageUtil.localStorage.testLocal)
         console.log('----> 33PUDB linkToExternalSearchSystemController');
         var lastResult = this.parentCtrl.searchStateService.resultObject.info.last;


### PR DESCRIPTION
@louxfaure j'ai remarqué qu'il reste un problème avec la modifciation que tu as faite, quand on affiche une notice depuis la liste de résultats c'est bon, mais si on raffraichit ou qu'on arrive à la notice depuis un permalien, le bandeau de recherche est présent (sur FF) car il teste une variable qui le fait planter.

Ajout d'un test dans le controller. Il y a sûrement une meilleure manière de le faire (via le ng-show ? )